### PR TITLE
Add service name into host header

### DIFF
--- a/servant/client/__init__.py
+++ b/servant/client/__init__.py
@@ -34,6 +34,8 @@ class Client(object):
     def configure(self, broker_type='local', **kwargs):
         if self.__transport is None:
             self.__transport = self.get_transport(broker_type)
+            kwargs['service_name'] = self.service_name
+            kwargs['service_version'] = self.service_version
             self.__transport.configure(**kwargs)
             self.__transport.connect()
 

--- a/servant/transport/http.py
+++ b/servant/transport/http.py
@@ -11,13 +11,18 @@ class HttpTransport(BaseTransport):
     def __repr__(self):
         return 'HttpTransport at %s' % (self.__url, )
 
-    def configure(self, host='localhost', port=8000, scheme='http'):
+    def configure(self, host='localhost', port=8000, scheme='http', **kwargs):
         self.__url = '%s://%s:%s' % (scheme, host, port)
+        self.__service_name = kwargs.get('service_name', 'servant')
+        self.__service_version = kwargs.get('service_version', '1')
 
     def is_connected(self):
         return True
 
     def send(self, data):
-        headers = {'content-type': 'application/json'}
+        headers = {
+                'host': self.__service_name,
+                'content-type': 'application/json',
+        }
         response = requests.post(self.__url, data=data, headers=headers)
         return response.text

--- a/servant/transport/local.py
+++ b/servant/transport/local.py
@@ -13,7 +13,7 @@ class LocalTransport(BaseTransport):
     def __repr__(self):
         return self.__class__.__name__
 
-    def configure(self, service_name='', service_version='', service_meta=None):
+    def configure(self, service_name='', service_version='', service_meta=None, **kwargs):
         instance = self._import_service_and_instantiate_service(service_name, service_version)
         self.service = instance
 


### PR DESCRIPTION
The `HOST` header will never be sent since we're not sending from a browser or 
other system which sets that, so override it as a way of identifying which endpoint/service
we'd like to hit.  This is useful specifically when using uwsgi's built-in HTTP router
which mathces against the `HOST` header. You can imagine matching against this in other
setups such as nginx.