### PR TITLE
Cast Error Messages to String

### DIFF
--- a/servant/service/base.py
+++ b/servant/service/base.py
@@ -410,7 +410,7 @@ class Service(object):
                 field_errors = errs.get(fieldname, [])
 
                 if isinstance(err, list):
-                    err = ', '.join(err)
+                    err = ', '.join([str(msg) for msg in err])
 
                 field_errors.append({
                         'error': err,


### PR DESCRIPTION
When a nested object throws a field error the list contains a dictionary with the nested field. This in turn throws an exception in the exception handler at this join operation, hiding the original exception. 