### PR TITLE
WSPC-15565 fix bunch py3.11 incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.4.3
 schematics==1.1.1
-bunch==1.0.1
+munch==4.0.0

--- a/servant/client/response.py
+++ b/servant/client/response.py
@@ -1,13 +1,13 @@
 from pprint import pformat
 
-import bunch
+import munch
 
 
 class Response(object):
 
     def __init__(self, data):
         self.__data = data
-        self.__object = bunch.Bunch.fromDict(data)
+        self.__object = munch.Munch.fromDict(data)
 
         self.__num_actions = len(self.__object.actions)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
         'requests>=2.4.3',
         'schematics==1.1.1',
-        'bunch==1.0.1',
+        'munch==4.0.0',
     ],
     tests_require=[
         'pytest>=2.6.4',


### PR DESCRIPTION
The upstream bunch package is broken in python3.11. "bunch" no longer gets updates, and has been abandoned by its creator. The fork "munch" fixes the issues.